### PR TITLE
S3 compatible platform support

### DIFF
--- a/build.ini
+++ b/build.ini
@@ -1,6 +1,6 @@
 VersionMajor=6
 VersionMinor=0
-VersionPatch=1
+VersionPatch=2
 BuildNo=%APPVEYOR_BUILD_NUMBER%
 
 ProjectName=Storage.Net

--- a/src/Storage.Net.Amazon.Aws/Blob/AwsS3BlobStorageProvider.cs
+++ b/src/Storage.Net.Amazon.Aws/Blob/AwsS3BlobStorageProvider.cs
@@ -163,9 +163,9 @@ namespace Storage.Net.Aws.Blob
             {
                //ETag contains actual MD5 hash, not sure why!
    
-               return new BlobMeta(
-                  obj.ContentLength,
-                  obj.ETag.Trim('\"'));  
+               return (obj != null) 
+                  ? new BlobMeta(obj.ContentLength, obj.ETag.Trim('\"')) 
+                  : null;  
             }
          }
          catch (StorageException ex) when (ex.ErrorCode == ErrorCode.NotFound)

--- a/src/Storage.Net.Amazon.Aws/Blob/AwsS3BlobStorageProvider.cs
+++ b/src/Storage.Net.Amazon.Aws/Blob/AwsS3BlobStorageProvider.cs
@@ -26,20 +26,40 @@ namespace Storage.Net.Aws.Blob
       //https://github.com/awslabs/aws-sdk-net-samples/blob/master/ConsoleSamples/AmazonS3Sample/AmazonS3Sample/S3Sample.cs
 
       /// <summary>
-      /// Creates a new instance of <see cref="AwsS3BlobStorageProvider"/>
+      /// Creates a new instance of <see cref="AwsS3BlobStorageProvider"/> for a given region endpoint/>
       /// </summary>
       public AwsS3BlobStorageProvider(string accessKeyId, string secretAccessKey, string bucketName, RegionEndpoint regionEndpoint)
+         : this(accessKeyId, secretAccessKey, bucketName, new AmazonS3Config { RegionEndpoint = regionEndpoint ?? RegionEndpoint.EUWest1 })
+      {
+      }
+
+      /// <summary>
+      /// Creates a new instance of <see cref="AwsS3BlobStorageProvider"/> for an S3-compatible storage provider hosted on an alternative service URL/>
+      /// </summary>
+      public AwsS3BlobStorageProvider(string accessKeyId, string secretAccessKey, string bucketName, string serviceUrl)
+         : this(accessKeyId, secretAccessKey, bucketName, new AmazonS3Config
+         {
+            RegionEndpoint = RegionEndpoint.USEast1,
+            ServiceURL = serviceUrl
+         })
+      {
+      }
+
+      /// <summary>
+      /// Creates a new instance of <see cref="AwsS3BlobStorageProvider"/> for a given S3 client configuration/>
+      /// </summary>
+      public AwsS3BlobStorageProvider(string accessKeyId, string secretAccessKey, string bucketName, AmazonS3Config clientConfig)
       {
          if(accessKeyId == null) throw new ArgumentNullException(nameof(accessKeyId));
          if(secretAccessKey == null) throw new ArgumentNullException(nameof(secretAccessKey));
-
-         if (regionEndpoint == null) regionEndpoint = RegionEndpoint.EUWest1;
-         _client = new AmazonS3Client(new BasicAWSCredentials(accessKeyId, secretAccessKey), regionEndpoint);
-         _fileTransferUtility = new TransferUtility(_client);
          _bucketName = bucketName ?? throw new ArgumentNullException(nameof(bucketName));
+
+         _client = new AmazonS3Client(new BasicAWSCredentials(accessKeyId, secretAccessKey), clientConfig);
+         _fileTransferUtility = new TransferUtility(_client);
 
          Initialise();
       }
+
 
       private void Initialise()
       {

--- a/src/Storage.Net.Tests.Integration/Blobs/BlobStorageProviderTest.cs
+++ b/src/Storage.Net.Tests.Integration/Blobs/BlobStorageProviderTest.cs
@@ -249,6 +249,16 @@ namespace Storage.Net.Tests.Integration.Blobs
       }
 
       [Fact]
+      public async Task GetMeta_doesnt_exist_returns_null()
+      {
+         string id = RandomGenerator.RandomString;
+
+         BlobMeta meta = (await _storage.GetMetaAsync(new[] { id })).First();
+
+         Assert.Null(meta);
+      }
+
+      [Fact]
       public async Task Open_doesnt_exist_returns_null()
       {
          string id = RandomGenerator.RandomString;

--- a/src/Storage.Net.ZipFile/ZipFileBlobStorageProvider.cs
+++ b/src/Storage.Net.ZipFile/ZipFileBlobStorageProvider.cs
@@ -52,15 +52,22 @@ namespace Storage.Net.ZipFile
          var result = new List<BlobMeta>();
          ZipArchive zipArchive = GetArchive(false);
 
-         foreach(string id in ids)
+         foreach (string id in ids)
          {
             string nid = StoragePath.Normalize(id, false);
 
-            ZipArchiveEntry entry = zipArchive.GetEntry(id);
+            try
+            {
+               ZipArchiveEntry entry = zipArchive.GetEntry(nid);
 
-            long originalLength = entry.Length;
+               long originalLength = entry.Length;
 
-            result.Add(new BlobMeta(originalLength, null));
+               result.Add(new BlobMeta(originalLength, null));
+            }
+            catch (NullReferenceException)
+            {
+               result.Add(null);
+            }
          }
 
          return Task.FromResult<IEnumerable<BlobMeta>>(result);


### PR DESCRIPTION
Hello Ivan,

Firstly, congratulations on creating a great library... I think it's a really clean design and very easy to use, thanks for your great work!

I noticed that the AwsS3BlobStorageProvider is missing the constructors that would be required to use it with S3 compatible services like DreamObjects. I've added these constructors for your consideration.

I also found that the AwsS3BlobStorageProvider provider's GetMetaAsync method behaved differently to the equivalent methods in the DiskDirectoryBlobStorage provider and the AzureBlobStorageProvider in the situation where one of the blobs being requested doesn't exist. The latter two providers return null for the non-existent blobs, whereas the AwsS3BlobStorageProvider implementation throws a NullReferenceException when a non-existent blob is encountered. I've fixed this issue.  

I will create a separate pull request after this one including a unit test for that GetMetaAsync(missingFile) behaviour mentioned above, and will fix any other IBlobStorage providers that are failing it.

Cheers,

Dave.
