### PR TITLE
Correct the Blob and Key-Value titles and intro text, since they are …

### DIFF
--- a/doc/blobs.md
+++ b/doc/blobs.md
@@ -1,6 +1,6 @@
-# Key-Value Providers
+# Blob Storage Providers
 
-This page lists key-value storage providers available in Storage.Net
+This page lists blob storage providers available in Storage.Net
 
 ## Index
 

--- a/doc/keyvalue.md
+++ b/doc/keyvalue.md
@@ -1,6 +1,6 @@
-# Blob Storage Providers
+# Key-Value Storage Providers
 
-This page lists blob storage providers available in Storage.Net
+This page lists key-value storage providers available in Storage.Net
 
 ## Index
 


### PR DESCRIPTION
…switched.

The provider documentation for blobs and key-value have their titles and intro text switched.  Swap them with one-another.  Fixes #70