### PR TITLE
[Proposal] Use ListenAsync (blocking) and fix CT usage

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Messaging/AwsS3MessageReceiver.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Messaging/AwsS3MessageReceiver.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Amazon;

--- a/src/Azure/Storage.Net.Microsoft.Azure.Storage/Messaging/AzureStorageQueueReceiver.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Storage/Messaging/AzureStorageQueueReceiver.cs
@@ -185,13 +185,14 @@ namespace Storage.Net.Microsoft.Azure.Storage.Messaging
          {
             batch = await _queue.GetMessagesAsync(maxBatchSize, _messageVisibilityTimeout, null, null, cancellationToken);
          }
-         catch(WSE ex) when (ex.InnerException is TaskCanceledException)
+         catch(WSE ex) when(ex.InnerException is TaskCanceledException)
          {
             throw ex.InnerException;
          }
 
          if(batch == null)
             return null;
+
          List<QueueMessage> result = batch.Select(Converter.ToQueueMessage).ToList();
          return result.Count == 0 ? null : result;
       }

--- a/src/Azure/Storage.Net.Microsoft.ServiceFabric/Messaging/ServiceFabricReliableQueueReceiver.cs
+++ b/src/Azure/Storage.Net.Microsoft.ServiceFabric/Messaging/ServiceFabricReliableQueueReceiver.cs
@@ -1,9 +1,6 @@
 ﻿using Microsoft.ServiceFabric.Data;
 using Microsoft.ServiceFabric.Data.Collections;
-using Storage.Net.Messaging;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Storage.Net/Messaging/IMessageReceiver.cs
+++ b/src/Storage.Net/Messaging/IMessageReceiver.cs
@@ -32,10 +32,10 @@ namespace Storage.Net.Messaging
       Task DeadLetterAsync(QueueMessage message, string reason, string errorDescription, CancellationToken cancellationToken = default);
 
       /// <summary>
-      /// Starts automatic message pumping trying to use native features as much as possible. Message pump stops when you dispose the instance.
-      /// Disposing the instance will also stop message pump for you.
+      /// Starts automatic message pumping trying to use native features as much as possible. 
+      /// The task only completes when the cancellation token signals a cancel.
       /// </summary>
-      Task StartMessagePumpAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default);
+      Task ListenAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default);
 
       /// <summary>
       /// Notifies the backend that processing is still happening and message should be marked alive.

--- a/src/Storage.Net/Messaging/InMemoryMessagePublisherReceiver.cs
+++ b/src/Storage.Net/Messaging/InMemoryMessagePublisherReceiver.cs
@@ -16,14 +16,16 @@ namespace Storage.Net.Messaging
 
       public static InMemoryMessagePublisherReceiver CreateOrGet(string name)
       {
-         if (name == null) throw new ArgumentNullException(nameof(name));
+         if(name == null)
+            throw new ArgumentNullException(nameof(name));
 
          return _inMemoryMessagingNameToInstance.GetOrAdd(name, () => new InMemoryMessagePublisherReceiver());
       }
 
       public Task PutMessagesAsync(IReadOnlyCollection<QueueMessage> messages, CancellationToken cancellationToken = default)
       {
-         if (messages == null) return Task.FromResult(true);
+         if(messages == null)
+            return Task.FromResult(true);
 
          foreach(QueueMessage qm in messages)
          {

--- a/src/Storage.Net/Messaging/Large/LargeMessageContentMessageReceiver.cs
+++ b/src/Storage.Net/Messaging/Large/LargeMessageContentMessageReceiver.cs
@@ -52,9 +52,9 @@ namespace Storage.Net.Messaging.Large
 
       public Task<ITransaction> OpenTransactionAsync() => _parentReceiver.OpenTransactionAsync();
 
-      public Task StartMessagePumpAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default)
+      public Task ListenAsync(Func<IReadOnlyCollection<QueueMessage>, CancellationToken, Task> onMessageAsync, int maxBatchSize = 1, CancellationToken cancellationToken = default)
       {
-         return _parentReceiver.StartMessagePumpAsync(
+         return _parentReceiver.ListenAsync(
             (mms, ct) => DownloadingMessagePumpAsync(mms, onMessageAsync, ct),
             maxBatchSize, cancellationToken);
       }

--- a/test/Storage.Net.Tests.Integration/Trio/MessagingFixture.cs
+++ b/test/Storage.Net.Tests.Integration/Trio/MessagingFixture.cs
@@ -54,7 +54,7 @@ namespace Storage.Net.Tests.Integration.Messaging
          _pumpStarted = true;
 
          //start the pump
-         await Receiver.StartMessagePumpAsync(ReceiverPumpAsync, cancellationToken: _cts.Token, maxBatchSize: 500).ConfigureAwait(false);
+         await Receiver.ListenAsync(ReceiverPumpAsync, cancellationToken: _cts.Token, maxBatchSize: 500).ConfigureAwait(false);
       }
 
       public async Task<string> PutMessageAsync(QueueMessage message = null)


### PR DESCRIPTION
- Currently the semantics of using the cancellation token vs dispose are not consistent: Sometimes the background task in StartMessagePumpAsync is stopped with the CT and sometimes with Dispose()
- The CT in StartMessagePumpAsync is often not only used for cancelling the method itself but also to stop the started background task - this is a against best practices of using CTs
    - See for example: https://github.com/aspnet/Hosting/blob/master/src/Microsoft.Extensions.Hosting.Abstractions/BackgroundService.cs
    - To stop the processing, they use another (internal) CT
- I propose to switch to `ListenAsync` which blocks (when awaited) and can be stopped with the provided CT
    - If you don't want to block, you just don't await and stop the pump with the cancellation token later - sometimes dispose will also stop the pump (not consistent everywhere yet). 

Usage: 

**Inline:** 

```
using (var receiver = new AzureServiceBusReceiver(...))
{
    await receiver.ListenAsync(ct);
}
```

The listening can be stopped with the CT and then dispose cleans up the receiver. In theory you can call ListenAsync again (but usually this does not make sense). 

**With host builder:** 

```
public class MyBackgroundService : BackgroundService
{
    private IMessageReceiver _messageReceiver;

    public MyBackgroundService()
    {
        _messageReceiver = new AzureServiceBusReceiver(...);
    }

    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
    {
        await _messageReceiver.ListenAsync(stoppingToken);
    }

    public override void Dispose()
    {
        _messageReceiver.Dispose();
        base.Dispose();
    }
}

public static async Task Main(string[] args)
{
    var host = new HostBuilder()
        .ConfigureServices(services => services.AddSingleton(new ))
        .Build();

    await host.RunAsync();
}
```