### PR TITLE
Change etag from DateTime to string, to reflect updated api.

### DIFF
--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/Models/DirectoryItem.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/Models/DirectoryItem.cs
@@ -7,7 +7,7 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen2.Models
    {
       [JsonProperty("contentLength")] public int? ContentLength { get; set; }
 
-      [JsonProperty("etag")] public DateTime Etag { get; set; }
+      [JsonProperty("etag")] public string Etag { get; set; }
 
       [JsonProperty("group")] public string Group { get; set; }
 


### PR DESCRIPTION
Hi Ivan,

The REST API had changed ETag to a string format, so I've updated the code to prevent a JSON deserialisation exception. All the integration tests for it now pass. I couldn't find the unit tests for it, so I presume they've been deleted; if not, there should be a failing test in there.

Thanks,

Richard