### PR TITLE
changes required to support factory creation of S3 blob storage class…

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Factory.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Factory.cs
@@ -22,6 +22,24 @@ namespace Storage.Net
          return factory.Use(new AwsStorageModule());
       }
 
+
+      /// <summary>
+      /// Creates an Amazon S3 storage using assumed role permissions (useful when running the code wform within ECS tasks or lambda where you don't need to provide and manage accessKeys and secrets as the permissions are assumed via the IAM role the lambda or ecs tasks has assigned to it)
+      /// </summary>
+      /// <param name="factory">Factory reference</param>
+      /// <param name="bucketName">Bucket name</param>
+      /// <param name="regionEndpoint">Optionally set region endpoint. When not specified defaults to EU West</param>
+      /// <param name="skipBucketCreation">Directive to skip the creation of the S3 bucket if one does not exist</param>
+      /// <returns>A reference to the created storage</returns>
+      public static IBlobStorage AmazonS3BlobStorage(this IBlobStorageFactory factory,
+         string bucketName,
+         RegionEndpoint regionEndpoint = null,
+         bool skipBucketCreation = false)
+      {
+         return new AwsS3BlobStorageProvider(bucketName, regionEndpoint, skipBucketCreation);
+      }
+
+
       /// <summary>
       /// Creates an Amazon S3 storage
       /// </summary>

--- a/src/AWS/Storage.Net.Amazon.Aws/GlobalSuppressions.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/GlobalSuppressions.cs
@@ -1,0 +1,7 @@
+﻿
+// This file is used by Code Analysis to maintain SuppressMessage 
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given 
+// a specific target and scoped to a namespace, type, member, etc.
+
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0044:Add readonly modifier", Justification = "<Pending>", Scope = "member", Target = "~F:Storage.Net.Amazon.Aws.Blobs.AwsS3BlobStorageProvider._skipBucketCreation")]


### PR DESCRIPTION
Have made some very small changes to the AWS blob storage project.
When relying on  container or lambda based role permissions as opposed to explicit access key and secret permissions, you shouldn't have to pass any access key and secret details to the factory method.
So I only just added constructors to support this.
Also added a skipbucketcreation parameter the constructor methods as default\optional parameter.
Had to do this for my project. not sure if you want it in or not.