### PR TITLE
Enable aws.s3 connection strings without keyId/key

### DIFF
--- a/doc/blobs.md
+++ b/doc/blobs.md
@@ -176,8 +176,8 @@ IBlobStorage storage = StorageFactory.Blobs.FromConnectionString("aws.s3://keyId
 ```
 
 where:
-- **keyId** is access key ID.
-- **key** is secret access key.
+- **keyId** is (optional) access key ID.
+- **key** is (optional) secret access key.
 - **bucket** is bucket name.
 - **region** is an optional value and defaults to `EU West 1` if not specified. At the moment of this wring the following regions are supported. However as we are using the official AWS SDK, when region information changes, storage.net gets automatically updated.
   - `us-east-1`
@@ -201,6 +201,8 @@ where:
   - `cn-north-1`
   - `cn-northwest-1`
   - `ca-central-1`
+
+If **keyId** and **key** are omitted, the AWS SDK's default approach to credential resolution will be used. For example: if running in Lambda, it will assume the Lambda execution role; if there are credentials configured in ~/.aws, it will use those; etc.  See [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html) for more details.
 
 #### Native Operations
 

--- a/src/AWS/Storage.Net.Amazon.Aws/AwsStorageModule.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/AwsStorageModule.cs
@@ -21,7 +21,7 @@ namespace Storage.Net.Amazon.Aws
             string keyId = connectionString.Get("keyId");
             string key = connectionString.Get("key");
 
-            if((keyId == null) != (key == null))
+            if(string.IsNullOrEmpty(keyId) != string.IsNullOrEmpty(key))
             {
                throw new ArgumentException($"connection string requires both 'key' and 'keyId' parameters, or neither.");
             }
@@ -31,7 +31,7 @@ namespace Storage.Net.Amazon.Aws
 
             RegionEndpoint endpoint = RegionEndpoint.GetBySystemName(string.IsNullOrEmpty(region) ? "eu-west-1" : region);
 
-            if(keyId == null)
+            if(string.IsNullOrEmpty(keyId))
             {
                return new AwsS3BlobStorage(bucket, endpoint);
             }

--- a/src/AWS/Storage.Net.Amazon.Aws/AwsStorageModule.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/AwsStorageModule.cs
@@ -18,12 +18,23 @@ namespace Storage.Net.Amazon.Aws
       {
          if(connectionString.Prefix == "aws.s3")
          {
-            connectionString.GetRequired("keyId", true, out string keyId);
-            connectionString.GetRequired("key", true, out string key);
+            string keyId = connectionString.Get("keyId");
+            string key = connectionString.Get("key");
+
+            if((keyId == null) != (key == null))
+            {
+               throw new ArgumentException($"connection string requires both 'key' and 'keyId' parameters, or neither.");
+            }
+
             connectionString.GetRequired("bucket", true, out string bucket);
             string region = connectionString.Get("region");
 
             RegionEndpoint endpoint = RegionEndpoint.GetBySystemName(string.IsNullOrEmpty(region) ? "eu-west-1" : region);
+
+            if(keyId == null)
+            {
+               return new AwsS3BlobStorage(bucket, endpoint);
+            }
 
             return new AwsS3BlobStorage(keyId, key, bucket, endpoint);
          }

--- a/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
@@ -37,7 +37,7 @@ namespace Storage.Net.Amazon.Aws.Blobs
 
 
       /// <summary>
-      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for a given region endpoint, and will assume the runnning AWS ECS Task role credentials or Lambda role credentials />
+      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for a given region endpoint, and will assume the running AWS ECS Task role credentials or Lambda role credentials 
       /// </summary>
       public AwsS3BlobStorage(string bucketName, RegionEndpoint regionEndpoint, bool skipBucketCreation = false)
       {
@@ -49,7 +49,7 @@ namespace Storage.Net.Amazon.Aws.Blobs
 
 
       /// <summary>
-      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for a given region endpoint/>
+      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for a given region endpoint
       /// </summary>
       public AwsS3BlobStorage(string accessKeyId, string secretAccessKey, string bucketName, RegionEndpoint regionEndpoint, bool skipBucketCreation = false)
          : this(accessKeyId, secretAccessKey, bucketName, new AmazonS3Config { RegionEndpoint = regionEndpoint ?? RegionEndpoint.EUWest1 }, skipBucketCreation)
@@ -57,7 +57,7 @@ namespace Storage.Net.Amazon.Aws.Blobs
       }
 
       /// <summary>
-      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for an S3-compatible storage provider hosted on an alternative service URL/>
+      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for an S3-compatible storage provider hosted on an alternative service URL
       /// </summary>
       public AwsS3BlobStorage(string accessKeyId, string secretAccessKey, string bucketName, string serviceUrl, bool skipBucketCreation = false)
          : this(accessKeyId, secretAccessKey, bucketName, new AmazonS3Config
@@ -69,7 +69,7 @@ namespace Storage.Net.Amazon.Aws.Blobs
       }
 
       /// <summary>
-      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for a given S3 client configuration/>
+      /// Creates a new instance of <see cref="AwsS3BlobStorage"/> for a given S3 client configuration
       /// </summary>
       public AwsS3BlobStorage(string accessKeyId, string secretAccessKey, string bucketName, AmazonS3Config clientConfig, bool skipBucketCreation = false)
       {

--- a/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj
+++ b/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj
@@ -31,6 +31,7 @@
    <ItemGroup>
       <PackageReference Include="AWSSDK.Core" Version="3.3.103.15" />
       <PackageReference Include="AWSSDK.S3" Version="3.3.104.3" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.102" />
       <PackageReference Include="AWSSDK.SQS" Version="3.3.100.51" />
    </ItemGroup>
    <ItemGroup>


### PR DESCRIPTION
Also:
- Fixed a couple xmldoc errors
- Add AWSS3.SecurityToken, which is needed for the SDK to be able to assume roles