### PR TITLE
Fixed: AwsS3BlobStorage was never set to initialized 

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
@@ -96,6 +96,7 @@ namespace Storage.Net.Amazon.Aws.Blobs
             catch (AmazonS3Exception ex) when (ex.ErrorCode == "BucketAlreadyOwnedByYou")
             {
                //ignore this error as bucket already exists
+               _initialised = true;
             }
          }
 


### PR DESCRIPTION
Fixed: AwsS3BlobStorage was never set to initialized already existed. This caused a PutBucketRequest with every GetClient()