### PR TITLE
S3 Factory: Allowing to skip bucket creation when using access keys

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Factory.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Factory.cs
@@ -48,14 +48,16 @@ namespace Storage.Net
       /// <param name="secretAccessKey">Secret access key</param>
       /// <param name="bucketName">Bucket name</param>
       /// <param name="regionEndpoint">Optionally set region endpoint. When not specified defaults to EU West</param>
+      /// <param name="skipBucketCreation">Directive to skip the creation of the S3 bucket if one does not exist</param>
       /// <returns>A reference to the created storage</returns>
       public static IBlobStorage AmazonS3BlobStorage(this IBlobStorageFactory factory,
          string accessKeyId,
          string secretAccessKey,
          string bucketName,
-         RegionEndpoint regionEndpoint = null)
+         RegionEndpoint regionEndpoint = null,
+         bool skipBucketCreation = false)
       {
-         return new AwsS3BlobStorage(accessKeyId, secretAccessKey, bucketName, regionEndpoint);
+         return new AwsS3BlobStorage(accessKeyId, secretAccessKey, bucketName, regionEndpoint, skipBucketCreation);
       }
 
       /// <summary>


### PR DESCRIPTION
In our system the buckets are created via terraform. If a bucket does not exist, it is actually a configuration error somewhere in the pipeline where I'd expect a 'Bucket does not exist'-like exception.

Also, our IAM user accessing the S3 bucket doesn't have full access. For the extra `PutBucketRequest` I had to give the user the permission `s3:CreateBucket` when I actually only want to give the user read access.

By simply allowing to pass the `skipBucketCreation`-Parameter in the factory both issues can be resolved.