### PR TITLE
Azure Storage optimistic concurrency support

### DIFF
--- a/src/Azure/Storage.Net.Microsoft.Azure.ServiceBus/Converter.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.ServiceBus/Converter.cs
@@ -12,10 +12,13 @@ namespace Storage.Net.Microsoft.Azure.ServiceBus
          if(message == null)
             throw new ArgumentNullException(nameof(message));
 
-         var result = new Message(message.Content)
+         var result = new Message(message.Content);
+
+         if(message.Id != null)
          {
-            MessageId = message.Id
-         };
+            result.MessageId = message.Id;
+         }
+
          if(message.Properties != null && message.Properties.Count > 0)
          {
             foreach(KeyValuePair<string, string> prop in message.Properties)

--- a/src/Azure/Storage.Net.Microsoft.Azure.Storage/KeyValue/EntityAdapter.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Storage/KeyValue/EntityAdapter.cs
@@ -28,22 +28,22 @@ namespace Storage.Net.Microsoft.Azure.Storage.KeyValue
       {
          _row = row;
 
-         Init(row?.Id, true);
+         Init(row?.Id);
       }
 
       public EntityAdapter(Key rowId)
       {
-         Init(rowId, true);
+         Init(rowId);
       }
 
-      private void Init(Key rowId, bool useConcurencyKey)
+      private void Init(Key rowId)
       {
-         if (rowId == null)
+         if(rowId == null)
             throw new ArgumentNullException("rowId");
 
          PartitionKey = ToInternalId(rowId.PartitionKey);
          RowKey = ToInternalId(rowId.RowKey);
-         ETag = "*";
+         ETag = rowId.ETag;
       }
 
       public void ReadEntity(IDictionary<string, EntityProperty> properties, OperationContext operationContext)
@@ -56,9 +56,9 @@ namespace Storage.Net.Microsoft.Azure.Storage.KeyValue
          //Azure Lib calls this when it wants to transform this entity to a writeable one
 
          var dic = new Dictionary<string, EntityProperty>();
-         foreach (KeyValuePair<string, object> cell in _row)
+         foreach(KeyValuePair<string, object> cell in _row)
          {
-            if (cell.Value == null)
+            if(cell.Value == null)
             {
                continue;
             }
@@ -66,7 +66,7 @@ namespace Storage.Net.Microsoft.Azure.Storage.KeyValue
             EntityProperty ep;
             Type t = cell.Value.GetType();
 
-            if (!_typeToEntityPropertyFunc.TryGetValue(t, out Func<object, EntityProperty> factoryMethod))
+            if(!_typeToEntityPropertyFunc.TryGetValue(t, out Func<object, EntityProperty> factoryMethod))
             {
                ep = EntityProperty.GeneratePropertyForString(cell.Value.ToString());
             }

--- a/src/Storage.Net/ErrorCode.cs
+++ b/src/Storage.Net/ErrorCode.cs
@@ -6,23 +6,33 @@
    public enum ErrorCode
    {
       /// <summary>
-      /// Unknown error code
+      /// Unknown error code.
       /// </summary>
       Unknown,
 
       /// <summary>
-      /// Resource not found
+      /// Resource not found.
       /// </summary>
       NotFound,
 
       /// <summary>
-      /// Operation failed because a key already exists
+      /// Operation failed because a key already exists.
       /// </summary>
       DuplicateKey,
 
       /// <summary>
-      /// A conflict
+      /// Failed the precondition.
       /// </summary>
-      Conflict
+      PreconditionFailed,
+
+      /// <summary>
+      /// A conflict.
+      /// </summary>
+      Conflict,
+
+      /// <summary>
+      /// A bad request.
+      /// </summary>
+      BadRequest
    }
 }

--- a/src/Storage.Net/KeyValue/Key.cs
+++ b/src/Storage.Net/KeyValue/Key.cs
@@ -12,12 +12,24 @@ namespace Storage.Net.KeyValue
       /// </summary>
       /// <param name="partitionKey">Partition key</param>
       /// <param name="rowKey">Row key</param>
-      public Key(string partitionKey, string rowKey)
+      public Key(string partitionKey, string rowKey) : this(partitionKey, rowKey, "*")
       {
-         if(partitionKey == null) throw new ArgumentNullException(nameof(partitionKey));
+      }
+
+      /// <summary>
+      /// Constructs an instance of <see cref="Key"/>
+      /// </summary>
+      /// <param name="partitionKey">Partition key</param>
+      /// <param name="rowKey">Row key</param>
+      /// <param name="etag">ETag</param>
+      public Key(string partitionKey, string rowKey, string etag)
+      {
+         if(partitionKey == null)
+            throw new ArgumentNullException(nameof(partitionKey));
 
          PartitionKey = partitionKey;
          RowKey = rowKey;
+         ETag = etag;
       }
 
       /// <summary>
@@ -31,15 +43,23 @@ namespace Storage.Net.KeyValue
       public string RowKey { get; private set; }
 
       /// <summary>
+      /// ETag
+      /// </summary>
+      public string ETag { get; set; }
+
+      /// <summary>
       /// Equals
       /// </summary>
       public bool Equals(Key other)
       {
-         if (ReferenceEquals(other, null)) return false;
-         if (ReferenceEquals(other, this)) return true;
-         if (other.GetType() != GetType()) return false;
+         if(ReferenceEquals(other, null))
+            return false;
+         if(ReferenceEquals(other, this))
+            return true;
+         if(other.GetType() != GetType())
+            return false;
 
-         return other.PartitionKey == PartitionKey && other.RowKey == RowKey;
+         return other.PartitionKey == PartitionKey && other.RowKey == RowKey && other.ETag == ETag;
       }
 
       /// <summary>

--- a/src/Storage.Net/KeyValue/Value.cs
+++ b/src/Storage.Net/KeyValue/Value.cs
@@ -10,12 +10,19 @@ namespace Storage.Net.KeyValue
    /// </summary>
    public sealed class Value : IDictionary<string, object>, IEquatable<Value>
    {
-      private readonly Dictionary<string, object> _keyToValue = new Dictionary<string, object>(); 
+      private readonly Dictionary<string, object> _keyToValue = new Dictionary<string, object>();
+
+      /// <summary>
+      /// Creates a new instance from partition key, row key and ETag
+      /// </summary>
+      public Value(string partitionKey, string rowKey, string etag) : this(new Key(partitionKey, rowKey, etag))
+      {
+      }
 
       /// <summary>
       /// Creates a new instance from partition key and row key
       /// </summary>
-      public Value(string partitionKey, string rowKey) : this(new Key(partitionKey, rowKey))
+      public Value(string partitionKey, string rowKey) : this(partitionKey, rowKey, null)
       {
       }
 
@@ -36,21 +43,29 @@ namespace Storage.Net.KeyValue
       /// <summary>
       /// Partition key
       /// </summary>
-      public string PartitionKey { get { return Id.PartitionKey; }}
+      public string PartitionKey { get { return Id.PartitionKey; } }
 
       /// <summary>
       /// Row key
       /// </summary>
-      public string RowKey { get { return Id.RowKey; }}
+      public string RowKey { get { return Id.RowKey; } }
+
+      /// <summary>
+      /// ETag
+      /// </summary>
+      public string ETag { get { return Id.ETag; } set { Id.ETag = value; } }
 
       /// <summary>
       /// Checks row equality
       /// </summary>
       public bool Equals(Value other)
       {
-         if(ReferenceEquals(other, null)) return false;
-         if(ReferenceEquals(other, this)) return true;
-         if(GetType() != other.GetType()) return false;
+         if(ReferenceEquals(other, null))
+            return false;
+         if(ReferenceEquals(other, this))
+            return true;
+         if(GetType() != other.GetType())
+            return false;
 
          return other.Id.PartitionKey == Id.PartitionKey && other.Id.RowKey == Id.RowKey;
       }
@@ -177,7 +192,8 @@ namespace Storage.Net.KeyValue
       {
          get
          {
-            if (!_keyToValue.TryGetValue(key, out object value)) return null;
+            if(!_keyToValue.TryGetValue(key, out object value))
+               return null;
             return value;
          }
          set { Add(key, value); }
@@ -206,10 +222,12 @@ namespace Storage.Net.KeyValue
       /// </summary>
       /// <param name="rowKey">When specified, the clone receives this value for the Row Key</param>
       /// <param name="partitionKey">When speified, the clone receives this value for the Partition Key</param>
+      /// <param name="etag"></param>
       /// <returns></returns>
-      public Value Clone(string rowKey = null, string partitionKey = null)
+      public Value Clone(string rowKey = null, string partitionKey = null, string etag = null)
       {
-         var clone = new Value(partitionKey ?? PartitionKey, rowKey ?? RowKey);
+         var clone = new Value(partitionKey ?? PartitionKey, rowKey ?? RowKey, ETag ?? etag);
+
          foreach(KeyValuePair<string, object> pair in _keyToValue)
          {
             clone._keyToValue[pair.Key] = pair.Value;
@@ -231,7 +249,8 @@ namespace Storage.Net.KeyValue
       /// </summary>
       public static bool AreDistinct(IEnumerable<Value> rows)
       {
-         if (rows == null) return true;
+         if(rows == null)
+            return true;
 
          IEnumerable<IGrouping<Key, Value>> groups = rows.GroupBy(r => r.Id);
          IEnumerable<int> counts = groups.Select(g => g.Count());
@@ -245,17 +264,17 @@ namespace Storage.Net.KeyValue
       {
          Value masterRow = null;
 
-         foreach (Value row in rows)
+         foreach(Value row in rows)
          {
-            if (masterRow == null)
+            if(masterRow == null)
             {
                masterRow = row;
             }
             else
             {
-               foreach (KeyValuePair<string, object> cell in row)
+               foreach(KeyValuePair<string, object> cell in row)
                {
-                  if (!masterRow.ContainsKey(cell.Key))
+                  if(!masterRow.ContainsKey(cell.Key))
                   {
                      masterRow[cell.Key] = cell.Value;
                   }

--- a/src/Storage.Net/KeyValue/Value.cs
+++ b/src/Storage.Net/KeyValue/Value.cs
@@ -222,7 +222,7 @@ namespace Storage.Net.KeyValue
       /// </summary>
       /// <param name="rowKey">When specified, the clone receives this value for the Row Key</param>
       /// <param name="partitionKey">When speified, the clone receives this value for the Partition Key</param>
-      /// <param name="etag"></param>
+      /// <param name="etag">When specified, the clone receives this value for the ETag</param>
       /// <returns></returns>
       public Value Clone(string rowKey = null, string partitionKey = null, string etag = null)
       {


### PR DESCRIPTION
Introduced support to optimistic concurrency through the ETag.

When ETag's don't match an exception is thrown.
![image](https://user-images.githubusercontent.com/7607329/64533848-3f810880-d30c-11e9-9a6b-7f668aa985fe.png)

![image](https://user-images.githubusercontent.com/7607329/64533347-29bf1380-d30b-11e9-9b5e-76ca51d02b1f.png)

Fixed a bug on the Service Bus converter where if the message.Id was null it would override the value generated by Message.