### PR TITLE
Add continuation token support to list directories

### DIFF
--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/DirectoryBrowser.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/DirectoryBrowser.cs
@@ -74,11 +74,23 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen2
          string fs = parts[0];
          string relativePath = StoragePath.Combine(parts.Skip(1));
 
-         PathList list;
+         List<Path> list = new List<Path>();
 
          try
          {
-            list = await _api.ListPathAsync(fs, relativePath, recursive: options.Recurse).ConfigureAwait(false);
+            string continuation = null;
+            do
+            {
+               ApiResponse<PathList> response = await _api.ListPathAsync(fs, relativePath, recursive: options.Recurse, continuation: continuation)
+                  .ConfigureAwait(false);
+
+               list.AddRange(response.Content.Paths);
+
+               if(response.Headers.Contains("x-ms-continuation"))
+               {
+                  continuation = response.GetHeader("x-ms-continuation");
+               }
+            } while(continuation != null);
          }
          catch(ApiException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
          {
@@ -86,7 +98,7 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen2
             return new List<Blob>();
          }
 
-         IEnumerable<Blob> result = list.Paths.Select(p => LConvert.ToBlob(fs, p));
+         IEnumerable<Blob> result = list.Select(p => LConvert.ToBlob(fs, p));
 
          if(options.FilePrefix != null)
             result = result.Where(b => b.IsFolder || b.Name.StartsWith(options.FilePrefix));

--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/DirectoryBrowser.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/DirectoryBrowser.cs
@@ -84,6 +84,7 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen2
                ApiResponse<PathList> response = await _api.ListPathAsync(fs, relativePath, recursive: options.Recurse, continuation: continuation)
                   .ConfigureAwait(false);
 
+               await response.EnsureSuccessStatusCodeAsync();
                list.AddRange(response.Content.Paths);
 
                if(response.Headers.Contains("x-ms-continuation"))

--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/Rest/IDataLakeApi.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen2/Rest/IDataLakeApi.cs
@@ -73,7 +73,7 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen2.Rest
       /// <param name="timeoutSeconds">An optional operation timeout value in seconds. The period begins when the request is received by the service. If the timeout value elapses before the operation completes, the operation fails.</param>
       /// <returns></returns>
       [Get("/{filesystem}?resource=filesystem")]
-      Task<PathList> ListPathAsync(
+      Task<ApiResponse<PathList>> ListPathAsync(
          string filesystem,
          string directory = null,
          bool? recursive = true,


### PR DESCRIPTION
Hi Ivan,

I've changed ListPathAsync() to be able to return more than 5000 items. It's not the best of solutions (it'd be better to provide the continuation token to the user to choose when to continue), but is the least intrusive in terms of maintaining your interface definition. Not sure what you would like to do in terms of integration testing - I can see it works against my storage account.

Thanks