### PR TITLE
Support non-standard Azure Storage Queue URI

### DIFF
--- a/src/Azure/Storage.Net.Microsoft.Azure.Queues/AzureStorageQueueMessenger.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Queues/AzureStorageQueueMessenger.cs
@@ -2,7 +2,6 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Storage;
@@ -19,12 +18,58 @@ namespace Storage.Net.Microsoft.Azure.Queues
       private readonly ConcurrentDictionary<string, CloudQueue> _channelNameToQueue =
          new ConcurrentDictionary<string, CloudQueue>();
 
+      /// <summary>
+      /// Initializes a new instance of <see cref="AzureStorageQueueMessenger"/>.
+      /// </summary>
+      /// <param name="accountName">
+      /// The account name to authenticate with the Azure Storage Queue service.
+      /// Must not be <see langword="null"/> or empty.
+      /// </param>
+      /// <param name="storageKey">
+      /// The key to authenticate with the Azure Storage Queue service.
+      /// Must not be <see langword="null"/> or empty.
+      /// </param>
+      /// <param name="serviceUri">
+      /// An <see cref="Uri"/> that points to an implementation of an Azure Storage Queue service.
+      /// See <see cref="AzureStorageQueueMessenger(string,string)"/> if your not sure about this parameter.
+      /// Must not be <see langword="null"/>.
+      /// </param>
+      /// <exception cref="ArgumentNullException">
+      /// Thrown if any of the arguments is <see langword="null"/> or empty.
+      /// </exception>
+      public AzureStorageQueueMessenger(
+         string accountName, string storageKey, Uri serviceUri)
+      {
+         if(string.IsNullOrEmpty(accountName))
+            throw new ArgumentNullException(nameof(accountName));
+         if(string.IsNullOrEmpty(storageKey))
+            throw new ArgumentNullException(nameof(storageKey));
+         if(serviceUri is null)
+            throw new ArgumentNullException(nameof(serviceUri));
+         
+         _client = new CloudQueueClient(serviceUri, new StorageCredentials(accountName, storageKey));
+      }
+
+      /// <summary>
+      /// Initializes a new instance of <see cref="AzureStorageQueueMessenger"/>.
+      /// </summary>
+      /// <param name="accountName">
+      /// The account name to authenticate with the Azure Storage Queue service.
+      /// Must not be <see langword="null"/> or empty.
+      /// </param>
+      /// <param name="storageKey">
+      /// The key to authenticate with the Azure Storage Queue service.
+      /// Must not be <see langword="null"/> or empty.
+      /// </param>
+      /// <exception cref="ArgumentNullException">
+      /// Thrown if any of the arguments is <see langword="null"/>.
+      /// </exception>
       public AzureStorageQueueMessenger(
          string accountName, string storageKey)
       {
-         if(accountName is null)
+         if(string.IsNullOrEmpty(accountName))
             throw new ArgumentNullException(nameof(accountName));
-         if(storageKey is null)
+         if(string.IsNullOrEmpty(storageKey))
             throw new ArgumentNullException(nameof(storageKey));
 
          var account = new CloudStorageAccount(new StorageCredentials(accountName, storageKey), true);

--- a/src/Azure/Storage.Net.Microsoft.Azure.Queues/QueuesFactory.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Queues/QueuesFactory.cs
@@ -19,14 +19,19 @@ namespace Storage.Net
       /// Creates an instance of a publisher to Azure Storage Queues
       /// </summary>
       /// <param name="factory">Factory reference</param>
-      /// <param name="accountName">Account name</param>
-      /// <param name="storageKey">Storage key</param>
+      /// <param name="accountName">Account name. Must not be <see langword="null"/> or empty.</param>
+      /// <param name="storageKey">Storage key. Must not be <see langword="null"/> or empty.</param>
+      /// <param name="serviceUri">Alternative service uri. Pass <see langword="null"/> for default.</param>
       /// <returns>Generic message publisher interface</returns>
       public static IMessenger AzureStorageQueue(this IMessagingFactory factory,
          string accountName,
-         string storageKey)
+         string storageKey,
+         Uri serviceUri = null)
       {
-         return new AzureStorageQueueMessenger(accountName, storageKey);   //
+         if (serviceUri == null)
+            return new AzureStorageQueueMessenger(accountName, storageKey);
+         
+         return new AzureStorageQueueMessenger(accountName, storageKey, serviceUri);
       }
 
       /// <summary>


### PR DESCRIPTION
### Fixes

n/a

### Description

The PR implements the possibility to create an Azure IMessenger implementation that does connect to an URL that is not the original Azure Storage Queue service. This is useful in development environments, where an implementation such as [Azurite](https://github.com/Azure/Azurite/) is used to provide the Storage Queue service.

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [ ] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.