### PR TITLE
Update azure.md to add v9 note

### DIFF
--- a/doc/blobs/azure.md
+++ b/doc/blobs/azure.md
@@ -2,6 +2,8 @@
 
 In order to use Microsoft Azure blob or file storage you need to reference [![NuGet](https://img.shields.io/nuget/v/Storage.Net.Microsoft.Azure.Storage.svg)](https://www.nuget.org/packages/Storage.Net.Microsoft.Azure.Storage/) package first. The provider wraps around the standard Microsoft Storage SDK.
 
+For Storage.Net v9 use the according specific package Blobs [![NuGet](https://img.shields.io/nuget/v/Storage.Net.Microsoft.Azure.Storage.Blobs.svg)](https://www.nuget.org/packages/Storage.Net.Microsoft.Azure.Storage.Blobs/) wich is available for v9.
+
 ## File Shares
 
 To create file share by storage name and key:


### PR DESCRIPTION
Adds a note for using Storage.Net v9 with Azure Blobs.
see https://github.com/aloneguid/storage/issues/165

It is very hard to resolve the problems you get if using the current version (v9) of Storage.Net and the given NuGet package in the documentation (which is only available up to v8).

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [x] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.