### PR TITLE
Checking if file exists before creating the empty file in CreateFolderAsync

### DIFF
--- a/src/Storage.Net/Blobs/BlobStorageExtensions.cs
+++ b/src/Storage.Net/Blobs/BlobStorageExtensions.cs
@@ -476,7 +476,8 @@ namespace Storage.Net.Blobs
          {
             string fullPath = StoragePath.Combine(folderPath, dummyFileName ?? ".empty");
 
-            // Check if the file already exists before we try to create it
+            // Check if the file already exists before we try to create it to prevent 
+            // AccessDenied exceptions if two processes are creating the folder at the same time.
             if(await blobStorage.ExistsAsync(fullPath))
             {
                return;

--- a/src/Storage.Net/Blobs/BlobStorageExtensions.cs
+++ b/src/Storage.Net/Blobs/BlobStorageExtensions.cs
@@ -476,6 +476,12 @@ namespace Storage.Net.Blobs
          {
             string fullPath = StoragePath.Combine(folderPath, dummyFileName ?? ".empty");
 
+            // Check if the file already exists before we try to create it
+            if(await blobStorage.ExistsAsync(fullPath))
+            {
+               return;
+            }
+
             await blobStorage.WriteTextAsync(
                fullPath,
                "created as a workaround by Storage.Net when creating an empty parent folder",


### PR DESCRIPTION
### Fixes

AccessDenied exceptions when creating a folder in disk blob storage from two processes at the same time.

### Description

When running multiple processes pointed to the same disk blob storage directory, running CreateFolderAsync at the same path on both services can cause AccessDenied exceptions because both processes are trying to create the .empty file.

`The process cannot access the file 'C:\\datamover\\health_check\\.empty' because it is being used by another process.`

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [ ] I have included unit/integration tests validating this fix.
- [ ] I have updated markdown documentation where required.