### PR TITLE
update AWSSDK.* packages

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj
+++ b/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj
@@ -27,10 +27,10 @@
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
    </PropertyGroup>
    <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="3.3.104.12" />
-      <PackageReference Include="AWSSDK.S3" Version="3.3.110.8" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.104.16" />
-      <PackageReference Include="AWSSDK.SQS" Version="3.3.102.51" />
+      <PackageReference Include="AWSSDK.Core" Version="3.5.1.2" />
+      <PackageReference Include="AWSSDK.S3" Version="3.5.0.4" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.5.0.4" />
+      <PackageReference Include="AWSSDK.SQS" Version="3.5.0.4" />
    </ItemGroup>
    <ItemGroup>
       <ProjectReference Include="..\..\Storage.Net\Storage.Net.csproj" />


### PR DESCRIPTION
### Fixes

Provider: AWS S3
Backend: [minio](https://min.io/)

`IBlobStorage.ExistsAsync` fails with 403 Forbidden when `fullPath` contains spaces.

### Description

```csharp
var config = new AmazonS3Config()
{
    ServiceURL = "http://minio-local",
    ForcePathStyle = true
};

var storage = StorageFactory.Blobs.AwsS3(
    "access-key",
    "secret-key",
    null,
    "bucket-name",
    config
);

// the next line throws an exception
var exists = await storage.ExistsAsync("path/with spaces/my file.bin");
```

following issues describe similar behavior:
https://github.com/minio/minio/issues/4162
https://github.com/aws/aws-sdk-net/issues/933

I have not found exact version when it was finally fixed but referencing latest AWSSDK.* packages in a client project resolves the issue.

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [x] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.