### PR TITLE
Support creating AzureDataLakeGen1Store by Credentials

### DIFF
--- a/doc/blobs.md
+++ b/doc/blobs.md
@@ -110,6 +110,15 @@ IBlobStorage storage = StorageFactory.Blobs.AzureDataLakeGen1StoreByClientSecret
          int listBatchSize = 5000)
 ```
 
+or
+
+```csharp
+IBlobStorage storage = StorageFactory.Blobs.AzureDataLakeGen1StoreByClientSecret(
+         string accountName,
+         ServiceClientCredentials credentials,
+         int listBatchSize = 5000)
+```
+
 The last parameter *listBatchSize* indicates how to query storage for list operations - by default a batch of 5k items will be used. Note that the larger the batch size, the more data you will receive in the request. This speeds up list operations, however may result in HTTP time-out the slower your internet connection is. This feature is not available in the standard .NET SDK and was implemented from scratch.
 
 You can also use connection strings:

--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/DataLakeGen1.csproj
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/DataLakeGen1.csproj
@@ -24,11 +24,9 @@
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
    </PropertyGroup>
    <ItemGroup>
-      <PackageReference Include="Microsoft.Azure.DataLake.Store" Version="1.1.19" />
-      <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.3.1" />
-      <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.0" />
+      <PackageReference Include="Microsoft.Azure.DataLake.Store" Version="1.1.21" />
+      <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.Authentication" Version="2.4.1" />
       <PackageReference Include="NetBox" Version="2.3.5" />
-      <PackageReference Include="System.Net.Http" Version="4.3.4" />
    </ItemGroup>
    <ItemGroup>
       <ProjectReference Include="..\..\Storage.Net\Storage.Net.csproj" />

--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Factory.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Factory.cs
@@ -1,4 +1,5 @@
-﻿using Storage.Net.Blobs;
+﻿using Microsoft.Rest;
+using Storage.Net.Blobs;
 using Storage.Net.Microsoft.Azure.DataLake.Store;
 using Storage.Net.Microsoft.Azure.DataLake.Store.Gen1;
 using System;
@@ -11,6 +12,8 @@ namespace Storage.Net
    /// </summary>
    public static class Factory
    {
+      private const int DefaultListBatchSize = 5000;
+
       /// <summary>
       /// Adds connection string support for Azure Data Lake Gen 1 and Gen 2
       /// </summary>
@@ -36,7 +39,7 @@ namespace Storage.Net
          string tenantId,
          string principalId,
          string principalSecret,
-         int listBatchSize = 5000)
+         int listBatchSize = DefaultListBatchSize)
       {
          if (accountName == null)
             throw new ArgumentNullException(nameof(accountName));
@@ -51,6 +54,30 @@ namespace Storage.Net
             throw new ArgumentNullException(nameof(principalSecret));
 
          var client = AzureDataLakeGen1Storage.CreateByClientSecret(accountName, new NetworkCredential(principalId, principalSecret, tenantId));
+         client.ListBatchSize = listBatchSize;
+         return client;
+      }
+
+      /// <summary>
+      /// Creates and instance of Azure Data Lake Store client with <code>ServiceClientCredentials</code>.
+      /// </summary>
+      /// <param name="factory">Factory reference</param>
+      /// <param name="accountName">Data Lake account name</param>
+      /// <param name="credentials">Service client credentials</param>
+      /// <param name="listBatchSize">Batch size for list operation for this storage connection. If not set defaults to 5000.</param>
+      /// <returns></returns>
+      public static IBlobStorage AzureDataLakeGen1StoreByCredentials(this IBlobStorageFactory factory,
+         string accountName,
+         ServiceClientCredentials credentials,
+         int listBatchSize = DefaultListBatchSize)
+      {
+         if(accountName == null)
+            throw new ArgumentNullException(nameof(accountName));
+
+         if(credentials == null)
+            throw new ArgumentNullException(nameof(credentials));
+
+         var client = AzureDataLakeGen1Storage.CreateByCredentials(accountName, credentials);
          client.ListBatchSize = listBatchSize;
          return client;
       }

--- a/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen1/AzureDataLakeGen1Storage.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.DataLake.Store/Gen1/AzureDataLakeGen1Storage.cs
@@ -34,6 +34,13 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen1
          _clientSecret = clientSecret;
       }
 
+      private AzureDataLakeGen1Storage(string accountName, ServiceClientCredentials credentials)
+      {
+         _accountName = accountName ?? throw new ArgumentNullException(nameof(accountName));
+
+         _credential = credentials ?? throw new ArgumentNullException(nameof(credentials));
+      }
+
       /// <summary>
       /// Returns the actual credential object used to authenticate to ADLS. Note that this will only be populated
       /// once you make at least one successful call.
@@ -62,6 +69,9 @@ namespace Storage.Net.Microsoft.Azure.DataLake.Store.Gen1
 
          return new AzureDataLakeGen1Storage(accountName, credential.Domain, credential.UserName, credential.Password, null);
       }
+
+      public static AzureDataLakeGen1Storage CreateByCredentials(string accountName, ServiceClientCredentials credentials)
+         => new AzureDataLakeGen1Storage(accountName, credentials);
 
       public async Task<IReadOnlyCollection<Blob>> ListAsync(ListOptions options, CancellationToken cancellationToken)
       {


### PR DESCRIPTION
### Description

Support creating AzureDataLakeGen1Store by Credentials directly.

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [ ] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.