### PR TITLE
Add support for writing metadata during blob upload for S3/Azure

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Blobs/IAwsS3BlobStorage.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Blobs/IAwsS3BlobStorage.cs
@@ -7,7 +7,7 @@ namespace Storage.Net.Amazon.Aws.Blobs
    /// <summary>
    /// Provides access to native operations
    /// </summary>
-   public interface IAwsS3BlobStorage : IBlobStorage
+   public interface IAwsS3BlobStorage : IBlobStorageWithMetadata
    {
       /// <summary>
       /// Returns reference to the native AWS S3 blob client.

--- a/src/Azure/Storage.Net.Microsoft.Azure.Storage.Blobs/IAzureBlobStorage.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Storage.Blobs/IAzureBlobStorage.cs
@@ -9,7 +9,7 @@ namespace Storage.Net.Microsoft.Azure.Storage.Blobs
    /// <summary>
    /// Azure blob storage specific operations
    /// </summary>
-   public interface IAzureBlobStorage : IBlobStorage
+   public interface IAzureBlobStorage : IBlobStorageWithMetadata
    {
       /// <summary>
       /// Acquires a lease

--- a/src/Storage.Net/Blobs/IBlobStorage.cs
+++ b/src/Storage.Net/Blobs/IBlobStorage.cs
@@ -78,4 +78,24 @@ namespace Storage.Net.Blobs
       /// <returns></returns>
       Task<ITransaction> OpenTransactionAsync();
    }
+
+   /// <summary>
+   /// Extend IBlobStorage to include WriteAsync overload which takes metadata. 
+   /// </summary>
+   public interface IBlobStorageWithMetadata : IBlobStorage
+   {
+      /// <summary>
+      /// Uploads data to a blob from stream.
+      /// overwritten.
+      /// </summary>
+      /// <param name="fullPath">Blob metadata</param>
+      /// <param name="dataStream">Stream to upload from</param>
+      /// <param name="metadata">Metadata to be applied to the blob</param>
+      /// <param name="cancellationToken"></param>
+      /// <param name="append">When true, appends to the file instead of writing a new one.</param>
+      /// <returns>Writeable stream</returns>
+      /// <exception cref="ArgumentNullException">Thrown when any parameter is null</exception>
+      /// <exception cref="ArgumentException">Thrown when ID is too long. Long IDs are the ones longer than 50 characters.</exception>
+      Task WriteAsync(string fullPath, Stream dataStream, Dictionary<string, string> metadata, bool append = false, CancellationToken cancellationToken = default);
+   }
 }

--- a/test/Storage.Net.Tests.Integration/Trio/BlobTest.cs
+++ b/test/Storage.Net.Tests.Integration/Trio/BlobTest.cs
@@ -515,6 +515,27 @@ namespace Storage.Net.Tests.Integration.Blobs
       }
 
       [Fact]
+      public async Task UserMetadata_writeAtUpload_readsback()
+      {
+         var blob = new Blob(RandomBlobPath());
+         blob.Metadata["user"] = "ivan";
+         blob.Metadata["fun"] = "no";
+
+         if(!(_storage is IBlobStorageWithMetadata storageWithMetadata))
+            return;
+
+         var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes("test"));
+         await storageWithMetadata.WriteAsync(blob, memoryStream, blob.Metadata);
+
+         //test
+         Blob blob2 = await _storage.GetBlobAsync(blob);
+         Assert.NotNull(blob2.Metadata);
+         Assert.Equal("ivan", blob2.Metadata["user"]);
+         Assert.Equal("no", blob2.Metadata["fun"]);
+         Assert.Equal(2, blob2.Metadata.Count);
+      }
+
+      [Fact]
       public async Task UserMetadata_OverwriteWithLess_RemovesOld()
       {
          //setup


### PR DESCRIPTION
Setting blob metadata appears to be a 2 step process - write the blob then set the metadata in a separate call. Ideally the metadata could be set and stored using the upload call. It might be nice to have an overload for WriteAsync that takes a blob object, however this PR may also work.

### Fixes

Issue # 203

### Description

desctiption goes here

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [ ] I have included unit/integration tests validating this fix.
- [ ] I have updated markdown documentation where required.