### PR TITLE
Mention package name in link

### DIFF
--- a/doc/blobs/awss3.md
+++ b/doc/blobs/awss3.md
@@ -1,6 +1,6 @@
 # AWS S3
 
-In order to use **S3** you need to reference [![NuGet](https://img.shields.io/nuget/v/Storage.Net.Amazon.Aws.svg)](https://www.nuget.org/packages/Storage.Net.Amazon.Aws/) package first. The provider wraps around the standard AWS SDK which is updated regularly, but adds a lot of untrivial workarounds that makes your life painless.
+In order to use **S3** you need to reference [Storage.Net.Amazon.Aws](https://www.nuget.org/packages/Storage.Net.Amazon.Aws/) [![NuGet](https://img.shields.io/nuget/v/Storage.Net.Amazon.Aws.svg)](https://www.nuget.org/packages/Storage.Net.Amazon.Aws/) package first. The provider wraps around the standard AWS SDK which is updated regularly, but adds a lot of untrivial workarounds that makes your life painless.
 
 ## Connecting
 


### PR DESCRIPTION
Documentation page just said `you need to reference nuget v9.2.7`, that was a bit confusing.

Now it shows the actual package you need to reference.