### PR TITLE
Bugfix/sas container paths

### DIFF
--- a/src/Azure/Storage.Net.Microsoft.Azure.Storage.Blobs/AzureBlobStorage.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Storage.Blobs/AzureBlobStorage.cs
@@ -511,7 +511,7 @@ namespace Storage.Net.Microsoft.Azure.Storage.Blobs
       {
          GenericValidation.CheckBlobFullPath(fullPath);
 
-         fullPath = StoragePath.Normalize(fullPath);
+         fullPath = StoragePath.Normalize(fullPath, true);
          if(fullPath == null)
             throw new ArgumentNullException(nameof(fullPath));
 

--- a/src/Azure/Storage.Net.Microsoft.Azure.Storage.Blobs/Factory.cs
+++ b/src/Azure/Storage.Net.Microsoft.Azure.Storage.Blobs/Factory.cs
@@ -187,7 +187,9 @@ namespace Storage.Net
       {
          TryParseSasUrl(sas, out string accountName, out string containerName, out string sasQuery);
 
-         var client = new BlobServiceClient(new Uri(sas));
+         var uriBuilder = new UriBuilder(GetServiceUri(accountName).AbsoluteUri);
+         uriBuilder.Query = sasQuery;
+         var client = new BlobServiceClient(uriBuilder.Uri);
 
          return new AzureBlobStorage(client, accountName, containerName: containerName);
       }

--- a/test/Storage.Net.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
+++ b/test/Storage.Net.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
@@ -27,7 +27,6 @@ namespace Storage.Net.Tests.Integration.Azure
       [Fact]
       public async Task Sas_Account()
       {
-
          var policy = new AccountSasPolicy(DateTime.UtcNow, TimeSpan.FromHours(1));
          policy.Permissions =
             AccountSasPermission.List |
@@ -42,7 +41,7 @@ namespace Storage.Net.Tests.Integration.Azure
          Assert.True(containers.Count > 0);
       }
 
-      /*[Fact]
+      [Fact]
       public async Task Sas_Container()
       {
          string fileName = Guid.NewGuid().ToString() + ".containersas.txt";
@@ -54,10 +53,10 @@ namespace Storage.Net.Tests.Integration.Azure
 
          //check we can connect and list test file in the root
          IBlobStorage sasInstance = StorageFactory.Blobs.AzureBlobStorageWithSas(sas);
-         IReadOnlyCollection<Blob> blobs = await sasInstance.ListAsync(StoragePath.RootFolderPath);
-         Blob testBlob = blobs.FirstOrDefault(b => b.FullPath == fileName);
+         IReadOnlyCollection<Blob> blobs = await sasInstance.ListAsync();
+         Blob testBlob = blobs.FirstOrDefault(b => b.Name == fileName);
          Assert.NotNull(testBlob);
-      }*/
+      }
 
       [Fact]
       public async Task ContainerPublicAccess()

--- a/test/Storage.Net.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
+++ b/test/Storage.Net.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
@@ -61,7 +61,7 @@ namespace Storage.Net.Tests.Integration.Azure
 
          //check we can connect and list test file in the root
          IBlobStorage sasInstance = StorageFactory.Blobs.AzureBlobStorageWithSas(sas);
-         IReadOnlyCollection<Blob> blobs = await sasInstance.ListAsync();
+         IReadOnlyCollection<Blob> blobs = await sasInstance.ListAsync(StoragePath.RootFolderPath);
          Blob testBlob = blobs.FirstOrDefault(b => b.Name == fileName);
          Assert.NotNull(testBlob);
       }

--- a/test/Storage.Net.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
+++ b/test/Storage.Net.Tests.Integration/Azure/LeakyAzureBlobStorageTest.cs
@@ -1,4 +1,6 @@
-﻿using Storage.Net.Blobs;
+﻿using Azure.Storage;
+using Azure.Storage.Blobs;
+using Storage.Net.Blobs;
 using Storage.Net.Microsoft.Azure.Storage.Blobs;
 using System;
 using System.Collections.Generic;
@@ -7,13 +9,15 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
+using AzureNative = global::Azure;
 
 namespace Storage.Net.Tests.Integration.Azure
 {
    [Trait("Category", "Blobs")]
    public class LeakyAzureBlobStorageTest
    {
-      private readonly IAzureBlobStorage _native;
+      private readonly IAzureBlobStorage _service;
+      private readonly BlobServiceClient _native;
 
       public LeakyAzureBlobStorageTest()
       {
@@ -21,7 +25,11 @@ namespace Storage.Net.Tests.Integration.Azure
 
          IBlobStorage storage = StorageFactory.Blobs.AzureBlobStorageWithSharedKey(
             settings.AzureStorageName, settings.AzureStorageKey);
-         _native = (IAzureBlobStorage)storage;
+         _service = (IAzureBlobStorage)storage;
+
+         _native = new BlobServiceClient(
+           new Uri($"https://{Settings.Instance.AzureStorageName}.blob.core.windows.net/"),
+           new StorageSharedKeyCredential(Settings.Instance.AzureStorageName, Settings.Instance.AzureStorageKey));
       }
 
       [Fact]
@@ -32,7 +40,7 @@ namespace Storage.Net.Tests.Integration.Azure
             AccountSasPermission.List |
             AccountSasPermission.Read |
             AccountSasPermission.Write;
-         string sas = await _native.GetStorageSasAsync(policy);
+         string sas = await _service.GetStorageSasAsync(policy);
          Assert.NotNull(sas);
 
          //check we can connect and list containers
@@ -46,10 +54,10 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string fileName = Guid.NewGuid().ToString() + ".containersas.txt";
          string filePath = StoragePath.Combine("test", fileName);
-         await _native.WriteTextAsync(filePath, "whack!");
+         await _service.WriteTextAsync(filePath, "whack!");
 
          var policy = new ContainerSasPolicy(DateTime.UtcNow, TimeSpan.FromHours(1));
-         string sas = await _native.GetContainerSasAsync("test", policy, true);
+         string sas = await _service.GetContainerSasAsync("test", policy, true);
 
          //check we can connect and list test file in the root
          IBlobStorage sasInstance = StorageFactory.Blobs.AzureBlobStorageWithSas(sas);
@@ -58,19 +66,49 @@ namespace Storage.Net.Tests.Integration.Azure
          Assert.NotNull(testBlob);
       }
 
+      [Theory]
+      [InlineData("")]
+      [InlineData("directory/")]
+      public async Task Sas_Container_StoresBlob_NameDoesNotContainLeadingOrDoubleSlash(string directoryName)
+      {
+         string fileName = Guid.NewGuid().ToString() + ".containersas.txt";
+         await _service.CreateFolderAsync("test");
+
+         var policy = new ContainerSasPolicy(DateTime.UtcNow, TimeSpan.FromHours(1));
+         policy.Permissions = ContainerSasPermission.Create;
+         string sas = await _service.GetContainerSasAsync("test", policy, true);
+
+         IBlobStorage sasInstance = StorageFactory.Blobs.AzureBlobStorageWithSas(sas);
+         await sasInstance.WriteTextAsync(directoryName + fileName, "file content");
+
+         AzureNative.Storage.Blobs.Models.BlobItem freshBlob = null;
+         BlobContainerClient nativeContainerClient = _native.GetBlobContainerClient("test");
+         await foreach(AzureNative.Storage.Blobs.Models.BlobItem blob in nativeContainerClient.GetBlobsAsync())
+         {
+            if(blob.Name.Contains(fileName))
+            {
+               freshBlob = blob;
+               break;
+            }
+         }
+
+         Assert.False(freshBlob.Name.StartsWith('/'));
+         Assert.DoesNotContain("//", freshBlob.Name);
+      }
+
       [Fact]
       public async Task ContainerPublicAccess()
       {
          //make sure container exists
-         await _native.WriteTextAsync("test/one", "test");
-         await _native.SetContainerPublicAccessAsync("test", ContainerPublicAccessType.Off);
+         await _service.WriteTextAsync("test/one", "test");
+         await _service.SetContainerPublicAccessAsync("test", ContainerPublicAccessType.Off);
 
-         ContainerPublicAccessType pa = await _native.GetContainerPublicAccessAsync("test");
+         ContainerPublicAccessType pa = await _service.GetContainerPublicAccessAsync("test");
          Assert.Equal(ContainerPublicAccessType.Off, pa);   //it's off by default
 
          //set to public
-         await _native.SetContainerPublicAccessAsync("test", ContainerPublicAccessType.Container);
-         pa = await _native.GetContainerPublicAccessAsync("test");
+         await _service.SetContainerPublicAccessAsync("test", ContainerPublicAccessType.Container);
+         pa = await _service.GetContainerPublicAccessAsync("test");
          Assert.Equal(ContainerPublicAccessType.Container, pa);
       }
 
@@ -79,14 +117,14 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string path = StoragePath.Combine("test", Guid.NewGuid().ToString() + ".txt");
 
-         await _native.WriteTextAsync(path, "read me!");
+         await _service.WriteTextAsync(path, "read me!");
 
          var policy = new BlobSasPolicy(DateTime.UtcNow, TimeSpan.FromHours(12))
          {
             Permissions = BlobSasPermission.Read | BlobSasPermission.Write
          };
 
-         string publicUrl = await _native.GetBlobSasAsync(path);
+         string publicUrl = await _service.GetBlobSasAsync(path);
 
          Assert.NotNull(publicUrl);
 
@@ -99,9 +137,9 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string id = $"test/{nameof(Lease_CanAcquireAndRelease)}.lck";
 
-         await _native.BreakLeaseAsync(id, true);
+         await _service.BreakLeaseAsync(id, true);
 
-         using(AzureStorageLease lease = await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)))
+         using(AzureStorageLease lease = await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)))
          {
             
          }
@@ -112,11 +150,11 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string id = $"test/{nameof(Lease_Break)}.lck";
 
-         await _native.BreakLeaseAsync(id, true);
+         await _service.BreakLeaseAsync(id, true);
 
-         await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20));
+         await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20));
 
-         await _native.BreakLeaseAsync(id);
+         await _service.BreakLeaseAsync(id);
       }
 
       [Fact]
@@ -124,11 +162,11 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string id = $"test/{nameof(Lease_FailsOnAcquiredLeasedBlob)}.lck";
 
-         await _native.BreakLeaseAsync(id, true);
+         await _service.BreakLeaseAsync(id, true);
 
-         using(AzureStorageLease lease1 = await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)))
+         using(AzureStorageLease lease1 = await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)))
          {
-            await Assert.ThrowsAsync<StorageException>(() => _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)));
+            await Assert.ThrowsAsync<StorageException>(() => _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)));
          }
       }
 
@@ -137,11 +175,11 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string id = $"test/{nameof(Lease_WaitsToReleaseAcquiredLease)}.lck";
 
-         await _native.BreakLeaseAsync(id, true);
+         await _service.BreakLeaseAsync(id, true);
 
-         using(AzureStorageLease lease1 = await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)))
+         using(AzureStorageLease lease1 = await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20)))
          {
-            await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20), null, true);
+            await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(20), null, true);
          }
       }
 
@@ -150,9 +188,9 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string id = "test";
 
-         await _native.BreakLeaseAsync(id, true);
+         await _service.BreakLeaseAsync(id, true);
 
-         using(AzureStorageLease lease = await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(15)))
+         using(AzureStorageLease lease = await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(15)))
          {
 
          }
@@ -163,17 +201,17 @@ namespace Storage.Net.Tests.Integration.Azure
       {
          string id = "test";
 
-         await _native.BreakLeaseAsync(id, true);
+         await _service.BreakLeaseAsync(id, true);
 
-         await _native.AcquireLeaseAsync(id, TimeSpan.FromSeconds(15));
+         await _service.AcquireLeaseAsync(id, TimeSpan.FromSeconds(15));
 
-         await _native.BreakLeaseAsync(id);
+         await _service.BreakLeaseAsync(id);
       }
 
       [Fact]
       public async Task Top_level_folders_are_containers()
       {
-         IReadOnlyCollection<Blob> containers = await _native.ListAsync();
+         IReadOnlyCollection<Blob> containers = await _service.ListAsync();
 
          foreach(Blob container in containers)
          {
@@ -187,13 +225,13 @@ namespace Storage.Net.Tests.Integration.Azure
       public async Task Delete_container()
       {
          string containerName = Guid.NewGuid().ToString();
-         await _native.WriteTextAsync($"{containerName}/test.txt", "test");
+         await _service.WriteTextAsync($"{containerName}/test.txt", "test");
 
-         IReadOnlyCollection<Blob> containers = await _native.ListAsync();
+         IReadOnlyCollection<Blob> containers = await _service.ListAsync();
          Assert.Contains(containers, c => c.Name == containerName);
 
-         await _native.DeleteAsync(containerName);
-         containers = await _native.ListAsync();
+         await _service.DeleteAsync(containerName);
+         containers = await _service.ListAsync();
          Assert.DoesNotContain(containers, c => c.Name == containerName);
       }
 


### PR DESCRIPTION
### Fixes

Issue #208 

### Description

This is to fix malformed paths generated by Azure Storage instance created with SAS which includes container name already

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [x] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.