### PR TITLE
Support DigitalOcean

### DIFF
--- a/doc/blobs.md
+++ b/doc/blobs.md
@@ -10,6 +10,7 @@ This page lists blob storage providers available in Storage.Net
 - [FTP](#ftp)
 - [Microsoft Azure Blob and File Storage](blobs/azure.md)
 - [Amazon S3 Storage](blobs/awss3.md)
+  - [DigitalOcean Spaces](blobs/awss3.md)
 - [Azure Data Lake Store](#azure-data-lake-store)
   - [Gen 1](#gen-1) 
   - [Gen 2](#gen-2)

--- a/doc/blobs/awss3.md
+++ b/doc/blobs/awss3.md
@@ -33,31 +33,40 @@ IBlobStorage storage = StorageFactory.Blobs.FromConnectionString("aws.s3://keyId
 where:
 - **keyId** is (optional) access key ID.
 - **key** is (optional) secret access key.
-- **bucket** is bucket name.
-- **region** is an optional value and defaults to `EU West 1` if not specified. At the moment of this wring the following regions are supported. However as we are using the official AWS SDK, when region information changes, storage.net gets automatically updated.
-  - `us-east-1`
-  - `us-east-2`
-  - `us-west-1`
-  - `us-west-2`
-  - `eu-north-1`
-  - `eu-west-1`
-  - `eu-west-2`
-  - `eu-west-3`
-  - `eu-central-1`
-  - `ap-northeast-1`
-  - `ap-northeast-2`
-  - `ap-northeast-3`
-  - `ap-south-1`
-  - `ap-southeast-1`
-  - `ap-southeast-2`
-  - `sa-east-1`
-  - `us-gov-east-1`
-  - `us-gov-west-1`
-  - `cn-north-1`
-  - `cn-northwest-1`
-  - `ca-central-1`
+  > If **keyId** and **key** are omitted, the AWS SDK's default approach to credential resolution will be used. For example: if running in Lambda, it will assume the Lambda execution role; if there are credentials configured in ~/.aws, it will use those; etc.  See [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html) for more details. This feature is not supported for connections with a custom **serviceUrl**.
 
-If **keyId** and **key** are omitted, the AWS SDK's default approach to credential resolution will be used. For example: if running in Lambda, it will assume the Lambda execution role; if there are credentials configured in ~/.aws, it will use those; etc.  See [AWS SDK Documentation](https://docs.aws.amazon.com/sdk-for-net/v3/developer-guide/net-dg-config-creds.html) for more details.
+- **bucket** is bucket name, i.e. `example-bucket`.
+  > Do _not_ use the full bucket url
+- **serviceUrl** 
+  > Optional and mutually exclusive with **region**. It overwrites the S3 service endpoint for use with 3rd party providers or On-Premise configurations.
+  > 
+  > Currently the following 3rd party providers are supported:
+  > - **DigitalOcean**  
+  >   Include the region in the serviceUrl, for example: `https://ams3.digitaloceanspaces.com`
+   
+- **region**  
+  > Required value (when **serviceUri** is absent), and defaults to `EU West 1` if not specified. At the moment of this writing the following regions are supported. However as we are using the official AWS SDK, when region information changes, storage.net gets automatically updated.
+  > - `us-east-1`
+  > - `us-east-2`
+  > - `us-west-1`
+  > - `us-west-2`
+  > - `eu-north-1`
+  > - `eu-west-1`
+  > - `eu-west-2`
+  > - `eu-west-3`
+  > - `eu-central-1`
+  > - `ap-northeast-1`
+  > - `ap-northeast-2`
+  > - `ap-northeast-3`
+  > - `ap-south-1`
+  > - `ap-southeast-1`
+  > - `ap-southeast-2`
+  > - `sa-east-1`
+  > - `us-gov-east-1`
+  > - `us-gov-west-1`
+  > - `cn-north-1`
+  > - `cn-northwest-1`
+  > - `ca-central-1`
 
 ## AWS CLI Profile Support
 

--- a/src/AWS/Storage.Net.Amazon.Aws/AwsStorageModule.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/AwsStorageModule.cs
@@ -16,7 +16,13 @@ namespace Storage.Net.Amazon.Aws
          {
             string cliProfileName = connectionString.Get(KnownParameter.LocalProfileName);
             connectionString.GetRequired(KnownParameter.BucketName, true, out string bucket);
-            connectionString.GetRequired(KnownParameter.Region, true, out string region);
+            string serviceUrl = connectionString.Get(KnownParameter.ServiceUrl);
+            string region = connectionString.Get(KnownParameter.Region);
+
+            if(string.IsNullOrEmpty(serviceUrl) == string.IsNullOrEmpty(region))
+            {
+               throw new ArgumentException($"connection string requires either a 'region' or a 'serviceUrl' parameter.");
+            }
 
             if(string.IsNullOrEmpty(cliProfileName))
             {
@@ -29,13 +35,14 @@ namespace Storage.Net.Amazon.Aws
                }
 
 
-               if(string.IsNullOrEmpty(keyId))
+               if(string.IsNullOrEmpty(keyId) && !string.IsNullOrEmpty(region))
                {
                   return new AwsS3BlobStorage(bucket, region);
                }
 
                string sessionToken = connectionString.Get(KnownParameter.SessionToken);
-               return new AwsS3BlobStorage(keyId, key, sessionToken, bucket, region, null);
+
+               return new AwsS3BlobStorage(keyId, key, sessionToken, bucket, region, serviceUrl);
             }
 #if !NET16
             else

--- a/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
@@ -122,7 +122,12 @@ namespace Storage.Net.Amazon.Aws.Blobs
             }
             catch(AmazonS3Exception ex) when(ex.ErrorCode == "BucketAlreadyOwnedByYou")
             {
-               //ignore this error as bucket already exists
+               // ignore this error as bucket already exists (S3)
+               _initialised = true;
+            }
+            catch(AmazonS3Exception ex) when(ex.ErrorCode == "Conflict")
+            {
+               // ignore this error as bucket already exists (DigitalOcean)
                _initialised = true;
             }
          }

--- a/src/Storage.Net/KnownParameter.cs
+++ b/src/Storage.Net/KnownParameter.cs
@@ -46,6 +46,11 @@ namespace Storage.Net
       /// Region
       /// </summary>
       public static readonly string Region = "region";
+      
+      /// <summary>
+      /// Service url (for on-premise S3)
+      /// </summary>
+      public static readonly string ServiceUrl = "serviceUrl";
 
       /// <summary>
       /// 

--- a/test/Storage.Net.Tests.Integration/AWS/AwsStorageModuleTests.cs
+++ b/test/Storage.Net.Tests.Integration/AWS/AwsStorageModuleTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Storage.Net.Amazon.Aws.Blobs;
+using Storage.Net.Blobs;
+using Xunit;
+
+namespace Storage.Net.Tests.Integration.AWS
+{
+   public class AwsStorageModuleTests
+   {
+      private static readonly IBlobStorageFactory Factory = StorageFactory.Blobs;
+      public AwsStorageModuleTests() => StorageFactory.Modules.UseAwsStorage();
+
+      [Fact]
+      public void FromConnectionString_WithBucketAndRegion_ReturnsAwsStorageModule()
+      {
+         IBlobStorage module = Factory.FromConnectionString("aws.s3://bucket=c;region=d");
+
+         Assert.IsAssignableFrom<IAwsS3BlobStorage>(module);
+      }
+
+      [Fact]
+      public void FromConnectionString_WithServiceUrl_WithoutRegion_ReturnsAwsStorageModule()
+      {
+         IBlobStorage module = Factory.FromConnectionString(
+            "aws.s3://keyId=a;key=b;bucket=c;serviceUrl=https://s3.example.local"
+         );
+
+         Assert.IsAssignableFrom<IAwsS3BlobStorage>(module);
+      }
+
+      [Fact]
+      public void FromConnectionString_WithoutServiceUrlAndRegion_ThrowsException() =>
+         Assert.Throws<ArgumentException>(() => Factory.FromConnectionString("aws.s3://keyId=a;key=b;bucket=c;"));
+
+      [Fact]
+      public void FromConnectionString_WithoutKeyIdButNoKey_ThrowsException() =>
+         Assert.Throws<ArgumentException>(() => Factory.FromConnectionString("aws.s3://keyId=a;bucket=c;region=d"));
+
+      [Fact]
+      public void FromConnectionString_WithoutKeyButNoKeyId_ThrowsException() =>
+         Assert.Throws<ArgumentException>(() => Factory.FromConnectionString("aws.s3://key=b;bucket=c;region=d"));
+
+      [Fact]
+      public void FromConnectionString_WithBucketAndCredentials()
+      {
+         IBlobStorage module = Factory.FromConnectionString(
+            "aws.s3://keyId=a;key=b;bucket=c;serviceUrl=https://s3.example.local"
+         );
+
+         Assert.IsAssignableFrom<IAwsS3BlobStorage>(module);
+      }
+   }
+}


### PR DESCRIPTION
Reopening this PR from my organization account. I've sponsored you, @aloneguid. Hopefully it will help to get this merged.

Not sure exactly why builds are failing, locally it builds fine, and the issue seems unrelated to my changes.

### Fixes

- https://github.com/aloneguid/storage/issues/195 - AWS S3 ServiceUrl via Connection String

Related issue:
- https://github.com/aloneguid/storage/issues/129

### Description

Support DigitalOcean Spaces, which is AWS S3 compatible.
- Allow overriding the ServiceUrl through connection strings, so DigitalOcean users can enjoy the flexibility of configuration without code, e.g:
`aws.s3://keyId=******;key=******/***************;bucket=example;serviceUrl=https://***.digitaloceanspaces.com`
- Detect when the bucket already existed on DigitalOcean. The current check only detects the AWS S3 errorcode (`You already own this bucket`), which is different from DigitalOcean (`Conflict`).
   - The approach of always creating a bucket is problematic in my opinion, and I feel should not be done upon client creation. In DigitalOcean, a bucket also costs $5 per month, and this way users may incur costs without realizing it.
   - This fix will at least allow the client to be instantiated, but a total opt-out like #129 is preferred. I would even make this opt-in, or completely remove the feature.
- Updated documentation
  - The docs still said that 'region' was optional, although the code for ConnectionStrings required it, so I changed the docs there.

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [x] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.