### PR TITLE
Added support for SSO generated credentials for AWS

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Blobs/AwsS3BlobStorage.cs
@@ -41,6 +41,11 @@ namespace Storage.Net.Amazon.Aws.Blobs
       {
          return new AwsS3BlobStorage(bucketName, region, AwsCliCredentials.GetCredentials(profileName));
       }
+      
+      public static AwsS3BlobStorage FromAwsCredentials(AwsCredentials credentials, string bucketName, string region)
+      {
+         return new AwsS3BlobStorage(bucketName, region, credentials);
+      }
 #endif
 
       public AwsS3BlobStorage(string bucketName, string region, AWSCredentials credentials)

--- a/src/AWS/Storage.Net.Amazon.Aws/Factory.cs
+++ b/src/AWS/Storage.Net.Amazon.Aws/Factory.cs
@@ -100,6 +100,22 @@ namespace Storage.Net
       {
          return AwsS3BlobStorage.FromAwsCliProfile(awsCliProfileName, bucketName, region);
       }
+      
+      /// <summary>
+      /// Creates an Amazon S3 storage provider using credentials retrieve from SSO
+      /// </summary>
+      /// <param name="factory">Factory reference</param>
+      /// <param name="credentials"></param>
+      /// <param name="bucketName">Bucket name</param>
+      /// <param name="region"></param>
+      /// <returns>A reference to the created storage</returns>
+      public static IBlobStorage AwsS3(this IBlobStorageFactory factory,
+         AWSCredentials credentials,
+         string bucketName,
+         string region)
+      {
+         return AwsS3BlobStorage.FromAwsCredentials(credentials, bucketName, region);
+      }
 #endif
 
       /// <summary>


### PR DESCRIPTION
### Fixes

Issue #164 

### Description

The PR contains the support for AWS factory to generate the IBlobStorage interface from the AWS Credentials resolved from the SSO interfaces such as SAML or Federated Auth.

- [x] I've made sure that this PR is raised against the [develop](https://github.com/aloneguid/storage/tree/develop) branch.
- [ ] I have included unit/integration tests validating this fix.
- [x] I have updated markdown documentation where required.