### PR TITLE
Upgrade AWS packages to retry on the transient error codes

### DIFF
--- a/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj
+++ b/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj
@@ -27,10 +27,10 @@
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
    </PropertyGroup>
    <ItemGroup>
-      <PackageReference Include="AWSSDK.Core" Version="3.3.104.12" />
-      <PackageReference Include="AWSSDK.S3" Version="3.3.110.8" />
-      <PackageReference Include="AWSSDK.SecurityToken" Version="3.3.104.16" />
-      <PackageReference Include="AWSSDK.SQS" Version="3.3.102.51" />
+      <PackageReference Include="AWSSDK.Core" Version="3.7.12.21" />
+      <PackageReference Include="AWSSDK.S3" Version="3.7.9.39" />
+      <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.1.185" />
+      <PackageReference Include="AWSSDK.SQS" Version="3.7.2.89" />
    </ItemGroup>
    <ItemGroup>
       <ProjectReference Include="..\..\Storage.Net\Storage.Net.csproj" />


### PR DESCRIPTION
### Fixes

Similar to Issue #234, the AWS packages are too outdated (the current version is [3.3.104.12](https://github.com/aloneguid/storage/blob/ad4f8a9d627cd93e91866a44a89922e857c59a2c/src/AWS/Storage.Net.Amazon.Aws/Storage.Net.Amazon.Aws.csproj)), and there would be no retries when transient error happens (the retry mechanism was introduced on in April 2020, version 3.3.714).

I update the packages to the latest ones, and successfully build it. 



 